### PR TITLE
Potential issue in sdk/thirdParty/imgui/imgui.cpp: Unchecked return from initialization function

### DIFF
--- a/sdk/thirdParty/imgui/imgui.cpp
+++ b/sdk/thirdParty/imgui/imgui.cpp
@@ -4160,7 +4160,7 @@ bool ImGui::Begin(const char* name, bool* p_open, const ImVec2& size_on_first_us
                 const ImVec2 br = window->Rect().GetBR();
                 const ImRect resize_rect(br - ImVec2(resize_corner_size * 0.75f, resize_corner_size * 0.75f), br);
                 const ImGuiID resize_id = window->GetID("#RESIZE");
-                bool hovered, held;
+                bool hovered, held = false;
                 ButtonBehavior(resize_rect, resize_id, &hovered, &held, ImGuiButtonFlags_FlattenChilds);
                 resize_col = GetColorU32(held ? ImGuiCol_ResizeGripActive : hovered ? ImGuiCol_ResizeGripHovered : ImGuiCol_ResizeGrip);
 
@@ -9476,7 +9476,7 @@ void ImGui::Columns(int columns_count, const char* id, bool border)
             if (IsClippedEx(column_rect, &column_id, false))
                 continue;
 
-            bool hovered, held;
+            bool hovered, held = false;
             ButtonBehavior(column_rect, column_id, &hovered, &held);
             if (hovered || held)
                 g.MouseCursor = ImGuiMouseCursor_ResizeEW;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**2 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `sdk/thirdParty/imgui/imgui.cpp` 
Enclosing Function : `Begin@ImGui`
Function : `ButtonBehavior@ImGui` 
https://github.com/sagpant/newton-dynamics/blob/e7571703bf8c5c75c5cabe754e51469ebbf60d77/sdk/thirdParty/imgui/imgui.cpp#L4164
**Issue in**: _held_

**Code extract**:

```cpp
                const ImRect resize_rect(br - ImVec2(resize_corner_size * 0.75f, resize_corner_size * 0.75f), br);
                const ImGuiID resize_id = window->GetID("#RESIZE");
                bool hovered, held;
                ButtonBehavior(resize_rect, resize_id, &hovered, &held, ImGuiButtonFlags_FlattenChilds); <------ HERE
                resize_col = GetColorU32(held ? ImGuiCol_ResizeGripActive : hovered ? ImGuiCol_ResizeGripHovered : ImGuiCol_ResizeGrip);

```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `sdk/thirdParty/imgui/imgui.cpp` 
Enclosing Function : `Columns@ImGui`
Function : `ButtonBehavior@ImGui` 
https://github.com/sagpant/newton-dynamics/blob/e7571703bf8c5c75c5cabe754e51469ebbf60d77/sdk/thirdParty/imgui/imgui.cpp#L9480
**Issue in**: _held_

**Code extract**:

```cpp
                continue;

            bool hovered, held;
            ButtonBehavior(column_rect, column_id, &hovered, &held); <------ HERE
            if (hovered || held)
                g.MouseCursor = ImGuiMouseCursor_ResizeEW;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
